### PR TITLE
Replace gpg --local-user and --default-key with --recipient

### DIFF
--- a/1password-backup.py
+++ b/1password-backup.py
@@ -157,12 +157,7 @@ def main():
             if args.force:
                 cmd.append('--yes')
             if args.key:
-                # The documentation claims only --local-user is necessary but
-                # in my real-world experience --default-key is definitely
-                # necessary and --local-user may be as well, so I include both
-                # here.
-                cmd.extend(['--default-key', args.key,
-                            '--local-user', args.key])
+                cmd.extend(['--recipient', args.key])
             cmd.append(args.output_file)
             subprocess.run(cmd, check=True)
             os.unlink(args.output_file)


### PR DESCRIPTION
macos built GPG via homebrew doesn't seem to honor `--local-user and `--default-key`, but it does respect `--recipient`. This PR fixes that concern by replacing the arguments. 